### PR TITLE
HTTP 400 on missing query

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const db 	   = require('db-hafas')
 const config       = require('config')
 const fs           = require('fs')
 const express      = require('express')
@@ -10,6 +9,8 @@ const corser       = require('corser')
 const compression  = require('compression')
 const nocache      = require('nocache')
 const path         = require('path')
+
+const locations    = require('./locations')
 
 const ssl = {
 	  key:  fs.readFileSync(config.key)
@@ -29,11 +30,7 @@ api.use(compression())
 const noCache = nocache()
 
 
-api.get('/locations', function(req, res, next){
-	db.locations(req.query.q)
-	.then((data) => {res.json(data)}, next)
-	.catch(next)
-})
+api.get('/locations', locations)
 
 api.use((err, req, res, next) => {
 	if (res.headersSent) return next()

--- a/locations.js
+++ b/locations.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const db = require('db-hafas')
+
+
+
+module.exports = (req, res, next) => {
+	db.locations(req.query.q)
+	.then((data) => {res.json(data)}, next)
+	.catch(next)
+}

--- a/locations.js
+++ b/locations.js
@@ -4,7 +4,18 @@ const db = require('db-hafas')
 
 
 
+const err400 = (msg) => {
+	const e = new Error(msg)
+	e.statusCode = 400
+	return e
+}
+
+
+
 module.exports = (req, res, next) => {
+	if ('string' !== typeof req.query.q)
+		return next(err400('missing q parameter.'))
+
 	db.locations(req.query.q)
 	.then((data) => {res.json(data)}, next)
 	.catch(next)


### PR DESCRIPTION
Althoug I'd like to rename the `q` parameter to `query`, I kept it like this for backwards-compatibility. But I propose to change it soon.  :stuck_out_tongue:
